### PR TITLE
Added dependency import statement.

### DIFF
--- a/Merit.g4
+++ b/Merit.g4
@@ -2,26 +2,47 @@ grammar Merit;
 
 parse: block EOF;
 
-block: (importDependency)*? WS* (statement)*;
+block: (importDependency)* WS* (statement)*;
 
-importDependency: IMPORT WS* IDENTIFIER WS* COLON WS* DEPENDENCY_NAME;
+importDependency: IMPORT WS* IDENTIFIER WS* COLON WS* (dependencyPathIdentifier)? (DEPENDENCY_NAME);
 
-statement: variableAssignment | outputAssignment;
+statement
+    : variableAssignment | outputAssignment
+    ;
 
-outputAssignment: OUTPUT WS* IDENTIFIER WS* assignment?;
+outputAssignment
+    : OUTPUT WS* simpleIdentifier WS* assignment?
+    ;
 
-variableAssignment:
-	variableModifier? WS* IDENTIFIER WS* assignment?;
+variableAssignment
+    : variableModifier? WS* simpleIdentifier WS* assignment?
+    ;
 
-assignment: (ASSIGN WS* expression);
+assignment
+    : (ASSIGN WS* expression)
+    ;
 
-expression: INTEGER # integerExpression;
+expression
+    : INTEGER # integerExpression
+    ;
 
-variableModifier: CONST | VAR;
+variableModifier
+    : CONST | VAR
+    ;
+
+dependencyPathIdentifier
+    : simpleIdentifier (WS* DOT simpleIdentifier)* DOT
+    ;
+
+simpleIdentifier
+    : IDENTIFIER
+    ;
 
 IMPORT: 'import';
 
 ASSIGN: '=';
+
+DOT: '.';
 
 OUTPUT: 'output';
 

--- a/Merit.g4
+++ b/Merit.g4
@@ -2,7 +2,9 @@ grammar Merit;
 
 parse: block EOF;
 
-block: (statement)*;
+block: (importDependency)*? WS* (statement)*;
+
+importDependency: IMPORT WS* IDENTIFIER WS* COLON WS* DEPENDENCY_NAME;
 
 statement: variableAssignment | outputAssignment;
 
@@ -17,6 +19,8 @@ expression: INTEGER # integerExpression;
 
 variableModifier: CONST | VAR;
 
+IMPORT: 'import';
+
 ASSIGN: '=';
 
 OUTPUT: 'output';
@@ -25,7 +29,13 @@ CONST: 'const';
 
 VAR: 'var';
 
+DEPENDENCY_NAME: (CAPITAL_LETTER) (LETTER | '_' | DIGIT)*;
+
 IDENTIFIER: (LETTER | '_') (LETTER | '_' | DIGIT)*;
+
+COLON: ':';
+
+CAPITAL_LETTER: [A-Z];
 
 LETTER: [a-zA-Z];
 


### PR DESCRIPTION
Added the ability to declare dependency variables using the `import` keyword.

### Examples
```
import greeter: Greeter
```

A path can be prepended to the dependency name to resolve a dependency that shares a name with another:
```
import greeter: org.merideum.Greeter
```

Since dependency imports are variables, other variables cannot be declared with the same identifier.

This would fail:
```
import greeter: Greeter

const greeter = "Hello!"
```