### PR TITLE
Optional Type Declaration and Negative Ints

### DIFF
--- a/MeritLexer.g4
+++ b/MeritLexer.g4
@@ -6,6 +6,8 @@ IMPORT: 'import';
 
 ASSIGN: '=';
 
+MINUS: '-';
+
 DOT: '.';
 
 OUTPUT: 'output';
@@ -59,6 +61,8 @@ E_DOT: '.' -> type(DOT);
 E_RESOURCE_NAME: (CAPITAL_LETTER) (LETTER | '_' | DIGIT)* -> type(RESOURCE_NAME);
 
 E_IDENTIFIER: (LETTER | '_') (LETTER | '_' | DIGIT)* -> type(IDENTIFIER);
+
+E_MINUS: '-' -> type(MINUS);
 
 E_COLON: ':' -> type(COLON);
 

--- a/MeritParser.g4
+++ b/MeritParser.g4
@@ -39,9 +39,9 @@ assignment
     ;
 
 expression
-    : expression functionCall                  # functionCallExpression
-    | simpleIdentifier                         # simpleIdentifierExpression
-    | INTEGER                                  # integerExpression
+    : expression functionCall                   # functionCallExpression
+    | simpleIdentifier                          # simpleIdentifierExpression
+    | MINUS? INTEGER                            # integerExpression
     | QUOTE_DOUBLE stringContent* QUOTE_DOUBLE  # stringExpression
     ;
 

--- a/MeritParser.g4
+++ b/MeritParser.g4
@@ -27,7 +27,7 @@ variableDeclaration
     ;
 
 variableDeclarationAssignment
-    : variableModifier WS* simpleIdentifier WS* assignment
+    : variableModifier WS* simpleIdentifier WS* typeDeclaration? WS* assignment
     ;
 
 variableReassignment


### PR DESCRIPTION
# Changes

## Added
* A type declaration can be included in a variable declaration-assignment statement. This is to support `nullable` types in the future (which require a type declaration if assigned to `null`.

Example:
```
const test: string = "Foobar"
```

* The minus sign can now be used to denote an integer as negative.
Example:
```
const negativeInt = -123
```