### PR TITLE
Added object field shorthand assignment.

### DIFF
--- a/MerideumParser.g4
+++ b/MerideumParser.g4
@@ -116,7 +116,7 @@ objectFields
     ;
 
 objectField
-    : simpleIdentifier WS* typeDeclaration? WS* assignment
+    : simpleIdentifier WS* typeDeclaration? WS* assignment?
     ;
 
 listElementAssignments


### PR DESCRIPTION
Objects fields can be assigned to the value of a variable with a shorthand:
```
const message = "Hello World!"

foo: object = {
    message
}
```